### PR TITLE
feat: add server health monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🚀 **STOP!** Are You Still Juggling 10+ Different AI Tools and Servers? 
 
-## **Introducing JustGoingViral: The ULTIMATE 68-in-1 MCP Server That's About to 10X Your AI Productivity!**
+## **Introducing JustGoingViral: The ULTIMATE 69-in-1 MCP Server That's About to 10X Your AI Productivity!**
 
-**✨ What if I told you that in the next 5 minutes, you could have access to 68 powerful AI tools, all perfectly integrated, all working together seamlessly, and all controlled from ONE single interface that works with ANY AI system?**
+**✨ What if I told you that in the next 5 minutes, you could have access to 69 powerful AI tools, all perfectly integrated, all working together seamlessly, and all controlled from ONE single interface that works with ANY AI system?**
 
 ### 🔥 **Here's What Industry Leaders Are Already Discovering:**
 
@@ -14,7 +14,7 @@
 
 ### **💎 Why Smart Developers Are Making The Switch:**
 
-✅ **68 Premium Tools** - Everything from filesystem operations to evolutionary AI thinking  
+✅ **69 Premium Tools** - Everything from filesystem operations to evolutionary AI thinking
 ✅ **Universal MCP Compatibility** - Works with ANY MCP client: Claude Desktop, Cline, ChatGPT connectors, custom AI systems  
 ✅ **Zero Configuration Headaches** - Plug-and-play with all MCP-compatible platforms  
 ✅ **Apple Ecosystem Mastery** - Native macOS integration others charge premium for  
@@ -33,7 +33,7 @@ While others are still manually switching between tools, YOU could be operating 
 
 # JustGoingViral MCP Server
 
-**Technical Overview:** A mega-consolidated MCP server compatible with ANY MCP client (Claude Desktop, Cline, ChatGPT connectors, custom AI systems) that integrates 68 tools from 10+ specialized servers into a single, powerful interface.
+**Technical Overview:** A mega-consolidated MCP server compatible with ANY MCP client (Claude Desktop, Cline, ChatGPT connectors, custom AI systems) that integrates 69 tools from 10+ specialized servers into a single, powerful interface.
 
 ## 🚀 Quick Setup (One Command)
 
@@ -49,9 +49,9 @@ This will:
 3. Make the setup script executable
 4. Run the automated setup (installs dependencies, builds project, shows instructions)
 
-## 🌟 Features - 68 Powerful Tools
+## 🌟 Features - 69 Powerful Tools
 
-**JustGoingViral is a mega-consolidated MCP server providing 68 tools across 10+ categories:**
+**JustGoingViral is a mega-consolidated MCP server providing 69 tools across 10+ categories:**
 
 ### 🍎 Apple Ecosystem Integration (8 tools)
 - `contacts`, `notes`, `messages`, `mail`, `reminders`, `webSearch`, `calendar`, `maps`
@@ -92,7 +92,10 @@ This will:
 ### 🗄️ Database Operations (1 tool)
 - `query` - PostgreSQL database operations
 
-**Total: 68 tools providing comprehensive automation, development, and productivity capabilities**
+### 🩺 Server Health Monitoring (1 tool)
+- `server_health` - Check server uptime, memory usage, and load averages
+
+**Total: 69 tools providing comprehensive automation, development, and productivity capabilities**
 
 ## Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { handleBrowserToolsTool } from "./thirdPartyWrappers/browserTools.js";
 import { handleMondayTool } from "./thirdPartyWrappers/monday.js";
 import { handleEvolutionaryIntelligenceTool } from "./thirdPartyWrappers/evolutionaryIntelligence.js";
 import { handleJustGoingViralTool } from "./thirdPartyWrappers/justGoingViral.js";
+import { handleServerHealthTool } from "./thirdPartyWrappers/serverHealth.js";
 
 console.error("Starting JustGoingViral consolidated MCP server...");
 
@@ -159,6 +160,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     
     if (mondayToolNames.includes(name)) {
       return await handleMondayTool(name, args);
+    }
+
+    // Route server health tool
+    if (name === 'server_health') {
+      return await handleServerHealthTool(name, args);
     }
 
     // Route Evolutionary Intelligence tools

--- a/src/thirdPartyWrappers/serverHealth.ts
+++ b/src/thirdPartyWrappers/serverHealth.ts
@@ -1,0 +1,32 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import os from 'os';
+
+export const serverHealthTools: Tool[] = [
+  {
+    name: 'server_health',
+    description: 'Returns current server health metrics like uptime, memory usage and load averages',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false
+    }
+  }
+];
+
+export async function handleServerHealthTool(name: string, _args: any) {
+  const uptimeSeconds = process.uptime();
+  const memory = process.memoryUsage();
+  const load = os.loadavg();
+  const info = {
+    uptimeSeconds,
+    memory,
+    loadAverage1m: load[0],
+    loadAverage5m: load[1],
+    loadAverage15m: load[2]
+  };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(info, null, 2) }],
+    isError: false
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -12,6 +12,7 @@ import { context7Tools } from './thirdPartyWrappers/context7.js';
 import { browserToolsTools } from './thirdPartyWrappers/browserTools.js';
 import { mondayTools } from './thirdPartyWrappers/monday.js';
 import { evolutionaryIntelligenceTools } from './thirdPartyWrappers/evolutionaryIntelligence.js';
+import { serverHealthTools } from './thirdPartyWrappers/serverHealth.js';
 const tools = [
   ...localAppleTools,
   ...filesystemTools,
@@ -23,6 +24,7 @@ const tools = [
   ...browserToolsTools,
   ...mondayTools,
   ...evolutionaryIntelligenceTools,
+  ...serverHealthTools,
 ];
 
 export default tools;


### PR DESCRIPTION
## Summary
- add `server_health` tool to report uptime, memory usage, and load averages
- register the tool within the consolidated server routing and tool registry
- document the new server health capability and updated total tool count

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68919c8e358c832890ee7c882c68ae38