### PR TITLE
feat: add server info tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🚀 **STOP!** Are You Still Juggling 10+ Different AI Tools and Servers? 
 
-## **Introducing JustGoingViral: The ULTIMATE 68-in-1 MCP Server That's About to 10X Your AI Productivity!**
+## **Introducing JustGoingViral: The ULTIMATE 69-in-1 MCP Server That's About to 10X Your AI Productivity!**
 
-**✨ What if I told you that in the next 5 minutes, you could have access to 68 powerful AI tools, all perfectly integrated, all working together seamlessly, and all controlled from ONE single interface that works with ANY AI system?**
+**✨ What if I told you that in the next 5 minutes, you could have access to 69 powerful AI tools, all perfectly integrated, all working together seamlessly, and all controlled from ONE single interface that works with ANY AI system?**
 
 ### 🔥 **Here's What Industry Leaders Are Already Discovering:**
 
@@ -14,7 +14,7 @@
 
 ### **💎 Why Smart Developers Are Making The Switch:**
 
-✅ **68 Premium Tools** - Everything from filesystem operations to evolutionary AI thinking  
+✅ **69 Premium Tools** - Everything from filesystem operations to evolutionary AI thinking
 ✅ **Universal MCP Compatibility** - Works with ANY MCP client: Claude Desktop, Cline, ChatGPT connectors, custom AI systems  
 ✅ **Zero Configuration Headaches** - Plug-and-play with all MCP-compatible platforms  
 ✅ **Apple Ecosystem Mastery** - Native macOS integration others charge premium for  
@@ -33,7 +33,7 @@ While others are still manually switching between tools, YOU could be operating 
 
 # JustGoingViral MCP Server
 
-**Technical Overview:** A mega-consolidated MCP server compatible with ANY MCP client (Claude Desktop, Cline, ChatGPT connectors, custom AI systems) that integrates 68 tools from 10+ specialized servers into a single, powerful interface.
+**Technical Overview:** A mega-consolidated MCP server compatible with ANY MCP client (Claude Desktop, Cline, ChatGPT connectors, custom AI systems) that integrates 69 tools from 10+ specialized servers into a single, powerful interface.
 
 ## 🚀 Quick Setup (One Command)
 
@@ -49,9 +49,9 @@ This will:
 3. Make the setup script executable
 4. Run the automated setup (installs dependencies, builds project, shows instructions)
 
-## 🌟 Features - 68 Powerful Tools
+## 🌟 Features - 69 Powerful Tools
 
-**JustGoingViral is a mega-consolidated MCP server providing 68 tools across 10+ categories:**
+**JustGoingViral is a mega-consolidated MCP server providing 69 tools across 10+ categories:**
 
 ### 🍎 Apple Ecosystem Integration (8 tools)
 - `contacts`, `notes`, `messages`, `mail`, `reminders`, `webSearch`, `calendar`, `maps`
@@ -92,7 +92,10 @@ This will:
 ### 🗄️ Database Operations (1 tool)
 - `query` - PostgreSQL database operations
 
-**Total: 68 tools providing comprehensive automation, development, and productivity capabilities**
+### 🧰 Utility (1 tool)
+- `server_info` - get server version and tool count
+
+**Total: 69 tools providing comprehensive automation, development, and productivity capabilities**
 
 ## Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,9 +92,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       throw new Error("No arguments provided");
     }
 
+    if (name === "server_info") {
+      return {
+        content: [{
+          type: "text",
+          text: `JustGoingViral v1.0.0 with ${tools.length} tools`
+        }],
+        isError: false
+      };
+    }
+
     // Route filesystem tools to their wrapper
     const filesystemToolNames = [
-      'read_file', 'read_multiple_files', 'write_file', 'edit_file', 
+      'read_file', 'read_multiple_files', 'write_file', 'edit_file',
       'create_directory', 'list_directory', 'list_directory_with_sizes',
       'directory_tree', 'move_file', 'search_files', 'get_file_info', 'list_allowed_directories'
     ];

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,6 +2,7 @@
  * Unified tool registry for the JustGoingViral server.
  */
 
+import { type Tool } from "@modelcontextprotocol/sdk/types.js";
 import localAppleTools from './utils/tools.js'; // Apple MCP utils
 import { filesystemTools } from './thirdPartyWrappers/filesystem.js';
 import { memoryTools } from './thirdPartyWrappers/memory.js';
@@ -12,7 +13,16 @@ import { context7Tools } from './thirdPartyWrappers/context7.js';
 import { browserToolsTools } from './thirdPartyWrappers/browserTools.js';
 import { mondayTools } from './thirdPartyWrappers/monday.js';
 import { evolutionaryIntelligenceTools } from './thirdPartyWrappers/evolutionaryIntelligence.js';
-const tools = [
+
+const serverInfoTool: Tool = {
+  name: "server_info",
+  description: "Get basic information about the JustGoingViral server",
+  inputSchema: {
+    type: "object",
+    properties: {}
+  }
+};
+const tools: Tool[] = [
   ...localAppleTools,
   ...filesystemTools,
   ...memoryTools,
@@ -23,6 +33,7 @@ const tools = [
   ...browserToolsTools,
   ...mondayTools,
   ...evolutionaryIntelligenceTools,
+  serverInfoTool,
 ];
 
 export default tools;


### PR DESCRIPTION
## Summary
- add `server_info` utility tool exposing server version and tool count
- document new tool and bump project totals to 69

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68919c7fb60c83288620acd8bf5d48a5