### PR TITLE
Add fallback for JustGoingViral tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     ];
 
     if (justGoingViralToolNames.includes(name)) {
-      return await handleJustGoingViralTool(name, args);
+      const result = await handleJustGoingViralTool(name, args);
+      if (!result.isError) {
+        return result;
+      }
+      // If the external JustGoingViral package is unavailable or fails,
+      // fall through to the local implementations below.
     }
 
     // Handle Apple MCP tools (simplified version - focusing on key tools)


### PR DESCRIPTION
## Summary
- add fallback to local Apple implementations when JustGoingViral package fails

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a13457108328bd714dfdb6f7fca0