### PR TITLE
Fix repository cloning instructions and start build process

### DIFF
--- a/CHATGPT_SETUP.md
+++ b/CHATGPT_SETUP.md
@@ -14,8 +14,8 @@ Create a REST API gateway that exposes the MCP tools as HTTP endpoints that Chat
 
 #### Step 1: Install JustGoingViral MCP Server
 ```bash
-git clone https://github.com/JustGoingViral/JustGoingViral-Mcp.git
-cd JustGoingViral-Mcp
+git clone https://github.com/JustGoingViral/JustGoingViral-Mcpo.git
+cd JustGoingViral-Mcpo
 npm install && npm run build
 ```
 
@@ -97,7 +97,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 ### Step 1: Run Your MCP Server
 ```bash
-cd JustGoingViral-Mcp
+cd JustGoingViral-Mcpo
 npm start
 ```
 

--- a/CLAUDE_DESKTOP_SETUP.md
+++ b/CLAUDE_DESKTOP_SETUP.md
@@ -18,14 +18,14 @@ This guide will walk you through connecting the JustGoingViral MCP server to Cla
 
 ### Option A: Quick Install (Recommended)
 ```bash
-git clone https://github.com/JustGoingViral/JustGoingViral-Mcp.git && cd JustGoingViral-Mcp && chmod +x setup.sh && ./setup.sh
+git clone https://github.com/JustGoingViral/JustGoingViral-Mcpo.git && cd JustGoingViral-Mcpo && chmod +x setup.sh && ./setup.sh
 ```
 
 ### Option B: Manual Install
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/JustGoingViral/JustGoingViral-Mcp.git
-   cd JustGoingViral-Mcp
+   git clone https://github.com/JustGoingViral/JustGoingViral-Mcpo.git
+   cd JustGoingViral-Mcpo
    ```
 
 2. **Install dependencies:**
@@ -74,17 +74,17 @@ If the file doesn't exist, create it. Add this configuration:
   "mcpServers": {
     "JustGoingViral": {
       "command": "node",
-      "args": ["/FULL/PATH/TO/JustGoingViral-Mcp/dist/index.js"]
+      "args": ["/FULL/PATH/TO/JustGoingViral-Mcpo/dist/index.js"]
     }
   }
 }
 ```
 
-**🚨 IMPORTANT:** Replace `/FULL/PATH/TO/JustGoingViral-Mcp/` with the actual path where you cloned the repository.
+**🚨 IMPORTANT:** Replace `/FULL/PATH/TO/JustGoingViral-Mcpo/` with the actual path where you cloned the repository.
 
 ### 3. **Find Your Full Path**
 
-To get the exact path, run this in your JustGoingViral-Mcp directory:
+To get the exact path, run this in your JustGoingViral-Mcpo directory:
 ```bash
 pwd
 ```
@@ -95,7 +95,7 @@ pwd
   "mcpServers": {
     "JustGoingViral": {
       "command": "node",
-      "args": ["/Users/yourname/JustGoingViral-Mcp/dist/index.js"]
+      "args": ["/Users/yourname/JustGoingViral-Mcpo/dist/index.js"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ While others are still manually switching between tools, YOU could be operating 
 Copy and paste this single command to get started:
 
 ```bash
-git clone https://github.com/JustGoingViral/JustGoingViral-Mcp.git && cd JustGoingViral-Mcp && chmod +x setup.sh && ./setup.sh
+git clone https://github.com/JustGoingViral/JustGoingViral-Mcpo.git && cd JustGoingViral-Mcpo && chmod +x setup.sh && ./setup.sh
 ```
 
 This will:
@@ -107,6 +107,11 @@ This will:
 3. Build the project:
    ```bash
    npm run build
+   ```
+
+4. Start the server:
+   ```bash
+   npm start
    ```
 
 ## Adding a New MCP Server

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "prestart": "npm run build",
     "start": "node dist/index.js",
     "add-mcp-server": "ts-node scripts/add-mcp-server.ts"
   },


### PR DESCRIPTION
## Summary
- Correct repository name in setup docs for ChatGPT and Claude Desktop
- Add prestart build step so `npm start` compiles TypeScript automatically
- Update README installation instructions and quick setup command

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npm start` *(server builds and starts; exits when stdin closed)*

------
https://chatgpt.com/codex/tasks/task_e_689ca85c17c48328becc0f8c18eab7c5