### PR TITLE
Add dev script for TypeScript server and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ This will:
    ```bash
    npm run build
    ```
+4. Start the server in development mode:
+   ```bash
+   npm run dev
+   ```
+   This runs the server directly from the TypeScript source. To run the compiled version instead, use:
+   ```bash
+   npm start
+   ```
 
 ## Adding a New MCP Server
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
+    "dev": "node --loader ts-node/esm src/index.ts",
     "add-mcp-server": "ts-node scripts/add-mcp-server.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add npm `dev` script to run TypeScript source via ts-node
- document how to start the server in development or compiled mode

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689ca8b2aadc8328a201fdfae5bc968a