### PR TITLE
Add tool listing utility for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ After running the automation script, you may need to:
 
 This server is designed to be used with Cline. Configure it in your MCP settings to use all the consolidated tools.
 
+To see a list of all available tools from the command line, run:
+
+```bash
+npm run list-tools
+```
+
 ## Development
 
 ### Project Structure

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "add-mcp-server": "ts-node scripts/add-mcp-server.ts"
+    "add-mcp-server": "ts-node scripts/add-mcp-server.ts",
+    "list-tools": "node --loader ts-node/esm scripts/list-tools.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.16.0",

--- a/scripts/list-tools.ts
+++ b/scripts/list-tools.ts
@@ -1,0 +1,7 @@
+import tools from '../src/tools.js';
+
+const toolNames = tools.map((t) => t.name);
+console.log('Available tools (' + toolNames.length + '):');
+for (const name of toolNames) {
+  console.log(`- ${name}`);
+}


### PR DESCRIPTION
## Summary
- add `npm run list-tools` script to display all available tools
- document usage of the new tool listing command

## Testing
- `npm run list-tools`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca8b2aadc8328a201fdfae5bc968a